### PR TITLE
Implemented #24 Consuming ResultSet more than once

### DIFF
--- a/src/main/java/net/ttddyy/dsproxy/proxy/ProxyJdbcObject.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/ProxyJdbcObject.java
@@ -11,6 +11,7 @@ package net.ttddyy.dsproxy.proxy;
  * @see net.ttddyy.dsproxy.proxy.jdk.StatementInvocationHandler
  * @see net.ttddyy.dsproxy.proxy.jdk.PreparedStatementInvocationHandler
  * @see net.ttddyy.dsproxy.proxy.jdk.CallableStatementInvocationHandler
+ * @see net.ttddyy.dsproxy.proxy.jdk.ResultSetInvocationHandler
  */
 public interface ProxyJdbcObject {
 

--- a/src/main/java/net/ttddyy/dsproxy/proxy/ResultSetProxyLogic.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/ResultSetProxyLogic.java
@@ -1,0 +1,166 @@
+package net.ttddyy.dsproxy.proxy;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
+
+public class ResultSetProxyLogic {
+
+    private final Map<String, Integer> columnNameToIndex;
+    private final ResultSet target;
+    private final int columnCount;
+
+    private int resultPointer;
+    private boolean resultSetConsumed;
+    private boolean closed;
+    private Object[] currentResult;
+    private final List<Object[]> cachedResults = new ArrayList<Object[]>();
+
+    private ResultSetProxyLogic(Map<String, Integer> columnNameToIndex, ResultSet target, int columnCount) throws SQLException {
+        this.columnNameToIndex = columnNameToIndex;
+        this.target = target;
+        this.columnCount = columnCount;
+    }
+
+    public static ResultSetProxyLogic resultSetProxyLogic(ResultSet target) throws SQLException {
+        ResultSetMetaData metaData = target.getMetaData();
+        int columnCount = metaData.getColumnCount();
+        return new ResultSetProxyLogic(columnNameToIndex(metaData), target, columnCount);
+    }
+
+    private static Map<String, Integer> columnNameToIndex(ResultSetMetaData metaData) throws SQLException {
+        Map<String, Integer> columnNameToIndex = new HashMap<String, Integer>();
+        for (int i = 1; i <= metaData.getColumnCount(); i++) {
+            columnNameToIndex.put(metaData.getColumnLabel(i).toUpperCase(), i);
+        }
+        return columnNameToIndex;
+    }
+
+    public Object invoke(Method method, Object[] args) throws Throwable {
+        if (isGetTargetMethod(method)) {
+            // ProxyJdbcObject interface has a method to return original object.
+            return target;
+        }
+        if (isGetMetaDataMethod(method)) {
+            return method.invoke(target, args);
+        }
+        if (isCloseMethod(method)) {
+            closed = true;
+            return method.invoke(target, args);
+        }
+        if (closed) {
+            throw new SQLException("Already closed");
+        }
+        if (resultSetConsumed) {
+            if (isGetMethod(method)) {
+                return handleGetMethodUsingCache(args);
+            }
+            if (isNextMethod(method)) {
+                return handleNextMethodUsingCache();
+            }
+        } else {
+            if (isGetMethod(method)) {
+                return handleGetMethodByDelegating(method, args);
+            }
+            if (isNextMethod(method)) {
+                return handleNextMethodByDelegating(method, args);
+            }
+            if (isBeforeFirstMethod(method)) {
+                resultPointer = -1;
+                resultSetConsumed = true;
+                return null;
+            }
+        }
+        throw new UnsupportedOperationException(format("Method '%s' is not supported by this proxy", method));
+    }
+
+    private Object handleNextMethodByDelegating(Method method, Object[] args) throws IllegalAccessException, InvocationTargetException {
+        Object result = method.invoke(target, args);
+        if (TRUE.equals(result)) {
+            currentResult = new Object[columnCount + 1];
+            cachedResults.add(currentResult);
+        }
+        return result;
+    }
+
+    private Object handleGetMethodByDelegating(Method method, Object[] args) throws SQLException, IllegalAccessException, InvocationTargetException {
+        int columnIndex = determineColumnIndex(args);
+        Object result = method.invoke(target, args);
+        currentResult[columnIndex] = result;
+        return result;
+    }
+
+    private Object handleNextMethodUsingCache() {
+        if (resultPointer < cachedResults.size() - 1) {
+            resultPointer++;
+            currentResult = cachedResults.get(resultPointer);
+            return true;
+        } else {
+            resultPointer++;
+            currentResult = null;
+            return false;
+        }
+    }
+
+    private Object handleGetMethodUsingCache(Object[] args) throws SQLException {
+        if (resultPointer == -1) {
+            throw new SQLException("Result set not advanced. Call next before any get method!");
+        } else if (resultPointer < cachedResults.size()) {
+            int columnIndex = determineColumnIndex(args);
+            return currentResult[columnIndex];
+        } else {
+            throw new SQLException(format("Result set exhausted. There were %d result(s) only", cachedResults.size()));
+        }
+    }
+
+    private boolean isCloseMethod(Method method) {
+        return method.getName().equals("close");
+    }
+
+    private boolean isGetTargetMethod(Method method) {
+        return method.getName().equals("getTarget");
+    }
+
+    private boolean isGetMetaDataMethod(Method method) {
+        return method.getName().equals("getMetaData");
+    }
+
+    private boolean isGetMethod(Method method) {
+        return method.getName().startsWith("get") && method.getParameterTypes().length > 0;
+    }
+
+    private boolean isNextMethod(Method method) {
+        return method.getName().equals("next");
+    }
+
+    private boolean isBeforeFirstMethod(Method method) {
+        return method.getName().equals("beforeFirst");
+    }
+
+    private int determineColumnIndex(Object[] args) throws SQLException {
+        Object lookup = args[0];
+        if (lookup instanceof Integer) {
+            return (Integer) lookup;
+        }
+        String columnName = (String) lookup;
+        Integer indexForColumnName = columnNameToIndex(columnName);
+        if (indexForColumnName != null) {
+            return indexForColumnName;
+        } else {
+            throw new SQLException(format("Unknown column name '%s'", columnName));
+        }
+    }
+
+    private Integer columnNameToIndex(String columnName) {
+        return columnNameToIndex.get(columnName.toUpperCase());
+    }
+}

--- a/src/main/java/net/ttddyy/dsproxy/proxy/jdk/ResultSetInvocationHandler.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/jdk/ResultSetInvocationHandler.java
@@ -1,0 +1,39 @@
+package net.ttddyy.dsproxy.proxy.jdk;
+
+import net.ttddyy.dsproxy.proxy.ProxyJdbcObject;
+import net.ttddyy.dsproxy.proxy.ResultSetProxyLogic;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.*;
+
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+
+/**
+ * Proxy InvocationHandler for {@link java.sql.ResultSet}.
+ *
+ * @author Liam Williams
+ */
+public class ResultSetInvocationHandler implements InvocationHandler {
+
+    private final ResultSetProxyLogic delegate;
+
+    public ResultSetInvocationHandler(ResultSetProxyLogic delegate) {
+        this.delegate = delegate;
+    }
+
+    public static ResultSet proxy(ResultSet target) throws SQLException {
+        ResultSetInvocationHandler resultSetProxy = new ResultSetInvocationHandler(ResultSetProxyLogic.resultSetProxyLogic(target));
+        return (ResultSet) Proxy.newProxyInstance(ProxyJdbcObject.class.getClassLoader(), new Class<?>[]{ProxyJdbcObject.class, ResultSet.class}, resultSetProxy);
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        return delegate.invoke(method, args);
+    }
+}

--- a/src/main/java/net/ttddyy/dsproxy/proxy/jdk/ResultSetProxyJdbcProxyFactory.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/jdk/ResultSetProxyJdbcProxyFactory.java
@@ -1,0 +1,43 @@
+package net.ttddyy.dsproxy.proxy.jdk;
+
+import net.ttddyy.dsproxy.proxy.InterceptorHolder;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+
+import static net.ttddyy.dsproxy.proxy.jdk.StatementResultSetResultInvocationHandler.statementResultSetResultProxy;
+
+/**
+ * Extension of {@link net.ttddyy.dsproxy.proxy.jdk.JdkJdbcProxyFactory} that also proxies any
+ * {@link java.sql.ResultSet} results so that they can be consumed more than once.
+ *
+ * @author Liam Williams
+ */
+public class ResultSetProxyJdbcProxyFactory extends JdkJdbcProxyFactory {
+
+    @Override
+    public Statement createStatement(Statement statement, InterceptorHolder interceptorHolder) {
+        return super.createStatement(statementResultSetResultProxy(statement, Statement.class), interceptorHolder);
+    }
+
+    @Override
+    public Statement createStatement(Statement statement, InterceptorHolder interceptorHolder, String dataSourceName) {
+        return super.createStatement(statementResultSetResultProxy(statement, Statement.class), interceptorHolder, dataSourceName);
+    }
+
+    @Override
+    public PreparedStatement createPreparedStatement(PreparedStatement preparedStatement, String query, InterceptorHolder interceptorHolder) {
+        return super.createPreparedStatement(statementResultSetResultProxy(preparedStatement, PreparedStatement.class), query, interceptorHolder);
+    }
+
+    @Override
+    public PreparedStatement createPreparedStatement(PreparedStatement preparedStatement, String query, InterceptorHolder interceptorHolder, String dataSourceName) {
+        return super.createPreparedStatement(statementResultSetResultProxy(preparedStatement, PreparedStatement.class), query, interceptorHolder, dataSourceName);
+    }
+
+    @Override
+    public CallableStatement createCallableStatement(CallableStatement callableStatement, String query, InterceptorHolder interceptorHolder, String dataSourceName) {
+        return super.createCallableStatement(statementResultSetResultProxy(callableStatement, CallableStatement.class), query, interceptorHolder, dataSourceName);
+    }
+}

--- a/src/main/java/net/ttddyy/dsproxy/proxy/jdk/StatementResultSetResultInvocationHandler.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/jdk/StatementResultSetResultInvocationHandler.java
@@ -1,0 +1,38 @@
+package net.ttddyy.dsproxy.proxy.jdk;
+
+import net.ttddyy.dsproxy.proxy.ProxyJdbcObject;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * This proxies any {@link java.sql.ResultSet} results so that they can be consumed more than once.
+ *
+ * @param <T> The {@link java.sql.Statement} type the proxy is for.
+ *
+ * @author Liam Williams
+ */
+class StatementResultSetResultInvocationHandler<T extends Statement> implements InvocationHandler {
+
+    private final T target;
+
+    private StatementResultSetResultInvocationHandler(T target) {
+        this.target = target;
+    }
+
+    public static <T extends Statement> T statementResultSetResultProxy(T target, Class<T> interfaceToProxy) {
+        return interfaceToProxy.cast(Proxy.newProxyInstance(ProxyJdbcObject.class.getClassLoader(), new Class<?>[]{ProxyJdbcObject.class, interfaceToProxy}, new StatementResultSetResultInvocationHandler<T>(target)));
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Object result = method.invoke(target, args);
+        if (result instanceof ResultSet) {
+            return ResultSetInvocationHandler.proxy((ResultSet) result);
+        }
+        return result;
+    }
+}

--- a/src/test/java/net/ttddyy/dsproxy/ResultSetProxyJdbcProxyFactoryTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/ResultSetProxyJdbcProxyFactoryTest.java
@@ -1,0 +1,134 @@
+package net.ttddyy.dsproxy;
+
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import net.ttddyy.dsproxy.proxy.jdk.ResultSetProxyJdbcProxyFactory;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.Test;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Liam Williams
+ */
+public class ResultSetProxyJdbcProxyFactoryTest {
+
+    @Test
+    public void checkThatResultSetCanBeConsumedMoreThanOnce() throws Exception {
+        JDBCDataSource dataSourceWithData = dataSourceWithData();
+
+        LoggingExecutionListener listener = new LoggingExecutionListener();
+        ProxyDataSource proxyDataSource = ProxyDataSourceBuilder.create(dataSourceWithData)
+                .listener(listener)
+                .build();
+        proxyDataSource.setJdbcProxyFactory(new ResultSetProxyJdbcProxyFactory());
+
+        checkThatResultSetCanBeConsumedViaTheProxyDataSource(proxyDataSource);
+        checkThatTheResultSetWasAlsoConsumedInTheListener(listener);
+    }
+
+    private void checkThatTheResultSetWasAlsoConsumedInTheListener(LoggingExecutionListener listener) {
+        assertThat(listener.table.columns).containsExactly("A", "B");
+        assertThat(listener.table.rows).containsExactly(
+                new String[]{"1", "2"},
+                new String[]{"3", "4"},
+                new String[]{"5", "6"}
+        );
+    }
+
+    private JDBCDataSource dataSourceWithData() throws SQLException {
+        JDBCDataSource dataSource = new JDBCDataSource();
+        dataSource.setDatabase("jdbc:hsqldb:mem:test");
+        Connection connection = dataSource.getConnection();
+        connection.createStatement().execute("CREATE TABLE test(a INT, b INT)");
+        connection.prepareStatement("INSERT INTO test(a, b) VALUES(1,2)").executeUpdate();
+        connection.prepareStatement("INSERT INTO test(a, b) VALUES(3,4)").executeUpdate();
+        connection.prepareStatement("INSERT INTO test(a, b) VALUES(5,6)").executeUpdate();
+        return dataSource;
+    }
+
+    private void checkThatResultSetCanBeConsumedViaTheProxyDataSource(ProxyDataSource proxyDataSource) throws SQLException {
+        Connection connection = proxyDataSource.getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("SELECT * from test");
+        ResultSet resultSet = preparedStatement.executeQuery();
+
+        resultSet.next();
+        assertThat(resultSet.getInt("a")).isEqualTo(1);
+        assertThat(resultSet.getInt(2)).isEqualTo(2);
+
+        resultSet.next();
+        assertThat(resultSet.getInt(1)).isEqualTo(3);
+        assertThat(resultSet.getInt("b")).isEqualTo(4);
+
+        resultSet.next();
+        assertThat(resultSet.getInt("a")).isEqualTo(5);
+        assertThat(resultSet.getInt("b")).isEqualTo(6);
+
+        assertThat(resultSet.next()).isFalse();
+        resultSet.close();
+    }
+
+    private static class LoggingExecutionListener implements QueryExecutionListener {
+
+        private Table table;
+
+        @Override
+        public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+
+        }
+
+        @Override
+        public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+            if (execInfo.getResult() instanceof ResultSet) {
+                table = extractTable((ResultSet) execInfo.getResult());
+            }
+        }
+
+        private static Table extractTable(ResultSet resultSet) {
+            try {
+                String[] columns = extractColumns(resultSet);
+                List<String[]> rows = new ArrayList<String[]>();
+                while (resultSet.next()) {
+                    rows.add(extractRow(resultSet));
+                }
+                resultSet.beforeFirst();
+                return new Table(columns, rows);
+            } catch (SQLException e) {
+                throw new IllegalStateException("Could not extract result set", e);
+            }
+        }
+
+        private static String[] extractColumns(ResultSet resultSet) throws SQLException {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            String[] columns = new String[metaData.getColumnCount()];
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                columns[i - 1] = metaData.getColumnLabel(i);
+            }
+            return columns;
+        }
+
+        private static String[] extractRow(ResultSet resultSet) throws SQLException {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            String[] row = new String[metaData.getColumnCount()];
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                row[i - 1] = String.valueOf(resultSet.getObject(i));
+            }
+            return row;
+        }
+    }
+
+    private static class Table {
+        private final String[] columns;
+        private final List<String[]> rows;
+
+        private Table(String[] columns, List<String[]> rows) {
+            this.columns = columns;
+            this.rows = rows;
+        }
+    }
+}

--- a/src/test/java/net/ttddyy/dsproxy/proxy/ResultSetProxyLogicTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/proxy/ResultSetProxyLogicTest.java
@@ -1,0 +1,305 @@
+package net.ttddyy.dsproxy.proxy;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class ResultSetProxyLogicTest {
+
+    private static final int NUMBER_OF_COLUMNS = 3;
+    private static final String COLUMN_1_LABEL = "FIRST";
+    private static final String COLUMN_2_LABEL = "SECOND";
+    private static final String COLUMN_3_LABEL = "THIRD";
+    private static final String COLUMN_1_VALUE = "result1";
+    private static final Integer COLUMN_2_VALUE = 999;
+    private static final Timestamp COLUMN_3_VALUE = new Timestamp(2312413L);
+
+    @Test
+    public void unsupportedMethodsThrowUnsupportedOperationException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        final Method getCursorName = ResultSet.class.getMethod("getCursorName");
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                resultSetProxyLogic.invoke(getCursorName, null);
+            }
+        }).isInstanceOf(UnsupportedOperationException.class).hasMessage("Method 'public abstract java.lang.String java.sql.ResultSet.getCursorName() throws java.sql.SQLException' is not supported by this proxy");
+    }
+
+    @Test
+    public void getTargetReturnsTheResultSetFromTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        Method getTarget = ProxyJdbcObject.class.getMethod("getTarget");
+
+        Object result = resultSetProxyLogic.invoke(getTarget, null);
+
+        assertThat(result).isSameAs(resultSet);
+    }
+
+    @Test
+    public void getResultSetMetaDataReturnsTheResultSetMetaDataFromTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        Method getMetaData = ResultSet.class.getMethod("getMetaData");
+
+        Object result = resultSetProxyLogic.invoke(getMetaData, null);
+
+        assertThat(result).isSameAs(resultSet.getMetaData());
+    }
+
+    @Test
+    public void closeCallsCloseOnTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        invokeClose(resultSetProxyLogic);
+
+        verify(resultSet).close();
+    }
+
+    @Test
+    public void getColumnOnResultSetThatHasBeenConsumedTwiceThrowsException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSet, resultSetProxyLogic);
+        consumeResultSet(resultSet, resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                ResultSetProxyLogicTest.this.invokeGetString(resultSetProxyLogic, 1);
+            }
+        }).isInstanceOf(SQLException.class).hasMessage("Result set exhausted. There were 2 result(s) only");
+    }
+
+    @Test
+    public void getColumnOnClosedResultSetThatHasBeenConsumedOnceThrowsException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSet, resultSetProxyLogic);
+        invokeClose(resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                ResultSetProxyLogicTest.this.invokeGetString(resultSetProxyLogic, 1);
+            }
+        }).isInstanceOf(SQLException.class).hasMessage("Already closed");
+    }
+
+    @Test
+    public void nextOnUnconsumedResultSetThatHasMoreResultsDelegatesToTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+        when(resultSet.next()).thenReturn(true);
+
+        boolean result = invokeNext(resultSetProxyLogic);
+
+        assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    public void nextOnUnconsumedResultThatHasNoMoreResultsSetDelegatesToTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+        when(resultSet.next()).thenReturn(false);
+
+        boolean result = invokeNext(resultSetProxyLogic);
+
+        assertThat(result).isEqualTo(false);
+    }
+
+    @Test
+    public void getColumnByIndexOnUnconsumedResultSetThatHasMoreResultsDelegatesToTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        invokeNext(resultSetProxyLogic);
+
+        int columnIndex = 1;
+        String columnValue = "result";
+        when(resultSet.getString(columnIndex)).thenReturn(columnValue);
+
+        String result = invokeGetString(resultSetProxyLogic, columnIndex);
+
+        assertThat(result).isEqualTo(columnValue);
+    }
+
+    @Test
+    public void getColumnByLabelOnUnconsumedResultSetThatHasMoreResultsDelegatesToTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        invokeNext(resultSetProxyLogic);
+
+        when(resultSet.getString(COLUMN_1_LABEL)).thenReturn(COLUMN_1_VALUE);
+
+        String result = invokeGetString(resultSetProxyLogic, COLUMN_1_LABEL);
+
+        assertThat(result).isEqualTo(COLUMN_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByIndexOnConsumedResultSetBeforeCallingNextThrowsSQLException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSet, resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                ResultSetProxyLogicTest.this.invokeGetString(resultSetProxyLogic, 1);
+            }
+        }).isInstanceOf(SQLException.class).hasMessage("Result set not advanced. Call next before any get method!");
+    }
+
+    @Test
+    public void getColumnByIndexOnConsumedResultSetThatHasMoreResultsReturnsTheResultThatTheTargetDidTheFirstTime() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSet, resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        String result = invokeGetString(resultSetProxyLogic, 1);
+
+        assertThat(result).isEqualTo(COLUMN_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByLabelOnConsumedResultSetThatHasMoreResultsReturnsTheResultThatTheTargetDidTheFirstTime() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSet, resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        String result = invokeGetString(resultSetProxyLogic, COLUMN_1_LABEL);
+
+        assertThat(result).isEqualTo(COLUMN_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByLabelOnConsumedResultSetWithUnknownLabelThrowsIllegalArgumentException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final ResultSetProxyLogic resultSetProxyLogic = ResultSetProxyLogic.resultSetProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSet, resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                invokeGetString(resultSetProxyLogic, "bad");
+            }
+        }).isInstanceOf(SQLException.class).hasMessage("Unknown column name 'bad'");
+    }
+
+    private void consumeResultSetAndCallBeforeFirst(ResultSet resultSet, ResultSetProxyLogic resultSetProxyLogic) throws Throwable {
+        consumeResultSet(resultSet, resultSetProxyLogic);
+        invokeBeforeFirst(resultSetProxyLogic);
+    }
+
+    private void consumeResultSet(ResultSet resultSet, ResultSetProxyLogic resultSetProxyLogic) throws Throwable {
+        when(resultSet.next()).thenReturn(true, true, false);
+
+        when(resultSet.getString(1)).thenReturn(COLUMN_1_VALUE);
+        when(resultSet.getInt(2)).thenReturn(COLUMN_2_VALUE);
+        when(resultSet.getTimestamp(3)).thenReturn(COLUMN_3_VALUE);
+
+        when(resultSet.getString(COLUMN_1_LABEL)).thenReturn(COLUMN_1_VALUE);
+        when(resultSet.getInt(COLUMN_2_LABEL)).thenReturn(COLUMN_2_VALUE);
+        when(resultSet.getTimestamp(COLUMN_3_LABEL)).thenReturn(COLUMN_3_VALUE);
+
+        assertThat(invokeNext(resultSetProxyLogic)).isTrue();
+        assertThat(invokeGetString(resultSetProxyLogic, COLUMN_1_LABEL)).isEqualTo(COLUMN_1_VALUE);
+        assertThat(invokeGetInt(resultSetProxyLogic, 2)).isEqualTo(COLUMN_2_VALUE);
+        assertThat(invokeGetTimestamp(resultSetProxyLogic, COLUMN_3_LABEL)).isEqualTo(COLUMN_3_VALUE);
+
+        assertThat(invokeNext(resultSetProxyLogic)).isTrue();
+        assertThat(invokeGetString(resultSetProxyLogic, 1)).isEqualTo(COLUMN_1_VALUE);
+        assertThat(invokeGetInt(resultSetProxyLogic, COLUMN_2_LABEL)).isEqualTo(COLUMN_2_VALUE);
+        assertThat(invokeGetTimestamp(resultSetProxyLogic, 3)).isEqualTo(COLUMN_3_VALUE);
+
+        assertThat(invokeNext(resultSetProxyLogic)).isFalse();
+    }
+
+    private void invokeClose(ResultSetProxyLogic resultSetProxyLogic) throws Throwable {
+        Method next = ResultSet.class.getMethod("close");
+        resultSetProxyLogic.invoke(next, null);
+    }
+
+    private void invokeBeforeFirst(ResultSetProxyLogic resultSetProxyLogic) throws Throwable {
+        Method beforeFirst = ResultSet.class.getMethod("beforeFirst");
+        resultSetProxyLogic.invoke(beforeFirst, null);
+    }
+
+    private boolean invokeNext(ResultSetProxyLogic resultSetProxyLogic) throws Throwable {
+        Method next = ResultSet.class.getMethod("next");
+        return (Boolean) resultSetProxyLogic.invoke(next, null);
+    }
+
+    private String invokeGetString(ResultSetProxyLogic resultSetProxyLogic, int columnIndex) throws Throwable {
+        Method getString = ResultSet.class.getMethod("getString", int.class);
+        return (String) resultSetProxyLogic.invoke(getString, new Object[]{columnIndex});
+    }
+
+    private int invokeGetInt(ResultSetProxyLogic resultSetProxyLogic, int columnIndex) throws Throwable {
+        Method getInt = ResultSet.class.getMethod("getInt", int.class);
+        return (Integer) resultSetProxyLogic.invoke(getInt, new Object[]{columnIndex});
+    }
+
+    private Timestamp invokeGetTimestamp(ResultSetProxyLogic resultSetProxyLogic, int columnIndex) throws Throwable {
+        Method getTimestamp = ResultSet.class.getMethod("getTimestamp", int.class);
+        return (Timestamp) resultSetProxyLogic.invoke(getTimestamp, new Object[]{columnIndex});
+    }
+
+    private String invokeGetString(ResultSetProxyLogic resultSetProxyLogic, String columnLabel) throws Throwable {
+        Method getString = ResultSet.class.getMethod("getString", String.class);
+        return (String) resultSetProxyLogic.invoke(getString, new Object[]{columnLabel});
+    }
+
+    private int invokeGetInt(ResultSetProxyLogic resultSetProxyLogic, String columnLabel) throws Throwable {
+        Method getInt = ResultSet.class.getMethod("getInt", String.class);
+        return (Integer) resultSetProxyLogic.invoke(getInt, new Object[]{columnLabel});
+    }
+
+    private Timestamp invokeGetTimestamp(ResultSetProxyLogic resultSetProxyLogic, String columnLabel) throws Throwable {
+        Method getTimestamp = ResultSet.class.getMethod("getTimestamp", String.class);
+        return (Timestamp) resultSetProxyLogic.invoke(getTimestamp, new Object[]{columnLabel});
+    }
+
+    private ResultSet exampleResultSet() throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        ResultSetMetaData resultSetMetaData = exampleResultSetMetaData();
+        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+        return resultSet;
+    }
+
+    private ResultSetMetaData exampleResultSetMetaData() throws SQLException {
+        ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+        when(metaData.getColumnCount()).thenReturn(NUMBER_OF_COLUMNS);
+        when(metaData.getColumnLabel(1)).thenReturn(COLUMN_1_LABEL);
+        when(metaData.getColumnLabel(2)).thenReturn(COLUMN_2_LABEL);
+        when(metaData.getColumnLabel(3)).thenReturn(COLUMN_3_LABEL);
+        return metaData;
+    }
+}

--- a/src/test/java/net/ttddyy/dsproxy/proxy/jdk/StatementResultSetResultInvocationHandlerTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/proxy/jdk/StatementResultSetResultInvocationHandlerTest.java
@@ -1,0 +1,26 @@
+package net.ttddyy.dsproxy.proxy.jdk;
+
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static net.ttddyy.dsproxy.proxy.jdk.StatementResultSetResultInvocationHandler.statementResultSetResultProxy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Liam Williams
+ */
+public class StatementResultSetResultInvocationHandlerTest {
+
+    @Test
+    public void nonResultSetResultMethodsPassThrough() throws SQLException {
+        PreparedStatement statement = mock(PreparedStatement.class);
+        PreparedStatement proxy = statementResultSetResultProxy(statement, PreparedStatement.class);
+
+        proxy.executeUpdate();
+
+        verify(statement).executeUpdate();
+    }
+}


### PR DESCRIPTION
There is now an alternative JdbcProxyFactory, ResultSetProxyJdbcProxyFactory, that intercepts any ResultSet results and proxies them with a ResultSet proxy that can be consumed more than once by calling the beforeFirst() method. This should only be used for small result sets, because the entire result set will be held in memory by the proxy.
