### PR TITLE
add posibility to specify Logger name for SLF4JQueryCountLogging

### DIFF
--- a/src/main/java/net/ttddyy/dsproxy/support/SLF4JQueryCountLoggingHandlerInterceptor.java
+++ b/src/main/java/net/ttddyy/dsproxy/support/SLF4JQueryCountLoggingHandlerInterceptor.java
@@ -28,4 +28,8 @@ public class SLF4JQueryCountLoggingHandlerInterceptor extends AbstractQueryCount
         this.logLevel = logLevel;
     }
 
+    public void setLogName(String logName) {
+        logger = LoggerFactory.getLogger(logName);
+    }
+
 }

--- a/src/main/java/net/ttddyy/dsproxy/support/SLF4JQueryCountLoggingServletFilter.java
+++ b/src/main/java/net/ttddyy/dsproxy/support/SLF4JQueryCountLoggingServletFilter.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SLF4JQueryCountLoggingServletFilter extends AbstractQueryCountLoggingServletFilter {
 
-    private static final Logger logger = LoggerFactory.getLogger(SLF4JQueryCountLoggingServletFilter.class);
+    private Logger logger = LoggerFactory.getLogger(SLF4JQueryCountLoggingServletFilter.class);
     private SLF4JLogLevel logLevel = SLF4JLogLevel.DEBUG;
 
     @Override
@@ -27,6 +27,10 @@ public class SLF4JQueryCountLoggingServletFilter extends AbstractQueryCountLoggi
 
     public void setLogLevel(SLF4JLogLevel logLevel) {
         this.logLevel = logLevel;
+    }
+
+    public void setLogName(String logName) {
+        logger = LoggerFactory.getLogger(logName);
     }
 
 }


### PR DESCRIPTION
With ProxyDataSourceBuilder we have possibility to specify logger Name, but we don't have possibility to specify logger name count logging