### PR TITLE
add support for AbstractQueryLogEntryCreator to handle operation "setXXX" with null value

### DIFF
--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLogEntryCreator.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLogEntryCreator.java
@@ -114,6 +114,9 @@ public abstract class AbstractQueryLogEntryCreator implements QueryLogEntryCreat
         if (ParameterSetOperation.isSetNullParameterOperation(param)) {
             // for setNull
             value = getDisplayValueForSetNull(param);
+        } else if (ParameterSetOperation.isSetXXXParameterOperation(param)) {
+            // for setXXX with null value
+            value = getDisplayValueForSetNull(param);
         } else if (ParameterSetOperation.isRegisterOutParameterOperation(param)) {
             // for registerOutParameter
             value = getDisplayValueForRegisterOutParameter(param);

--- a/src/main/java/net/ttddyy/dsproxy/proxy/ParameterSetOperation.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/ParameterSetOperation.java
@@ -35,6 +35,19 @@ public class ParameterSetOperation {
         return StatementMethodNames.PARAMETER_METHOD_SET_NULL.equals(methodName);
     }
 
+    /**
+     * Check the given operation is {@code setXXX} method by method name with passing null value.
+     *
+     * @param operation a parameter set operation
+     * @return true if it is a {@code setXXX} operation with null value
+     * @since 1.4
+     */
+    public static boolean isSetXXXParameterOperation(ParameterSetOperation operation) {
+        String methodName = operation.getMethod().getName();
+        Object arg = operation.getArgs()[1];
+        return methodName.startsWith("set") && arg == null;
+    }
+
     private Method method;
     private Object[] args;
 

--- a/src/test/java/net/ttddyy/dsproxy/listener/logging/LoggingListenerTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/listener/logging/LoggingListenerTest.java
@@ -89,6 +89,18 @@ public class LoggingListenerTest {
     }
 
     @Test
+    public void testPreparedStatementWithNullParam() throws Exception {
+        Connection connection = proxyDataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement("select ? as nullCol, name from emp where id = ?");
+        statement.setString(1, null);
+        statement.setInt(2, 2);
+        statement.executeQuery();
+
+        final InMemoryLog log = getInMemoryLog();
+        verifyMessage(CommonsLogLevel.DEBUG, log, "select ? as nullCol, name from emp where id = ?");
+    }
+
+    @Test
     public void testPreparedStatementWithBatch() throws Exception {
         Connection connection = proxyDataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement("update emp set name = ? where id = ?");


### PR DESCRIPTION
if i using `prepareStmt.setString(stringVar)` and setting `CommonsQueryLoggingListener` to log SQL info, when `stringVar==null` i get NullPointException.

this is try to resolve, thanks!