### PR TITLE
JUnit and Mockito should have test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>
@@ -295,6 +296,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
The JUnit and Mockito dependencies current have the default (compile)
scope. This is likely an oversight as these dependencies are only used
for tests.