### PR TITLE
ConnectionAcquiringListener: listener for connection lifecycle

### DIFF
--- a/src/main/java/net/ttddyy/dsproxy/listener/ChainConnectionAcquiringListener.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/ChainConnectionAcquiringListener.java
@@ -1,0 +1,58 @@
+package net.ttddyy.dsproxy.listener;
+
+import net.ttddyy.dsproxy.ConnectionInfo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ChainConnectionAcquiringListener implements ConnectionAcquiringListener {
+    private List<ConnectionAcquiringListener> listeners = new ArrayList<ConnectionAcquiringListener>();
+
+    @Override
+    public void beforeAcquireConnection(ConnectionInfo connectionInfo) {
+        for (ConnectionAcquiringListener listener : listeners) {
+            listener.beforeAcquireConnection(connectionInfo);
+        }
+    }
+
+    @Override
+    public void afterAcquireConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable) {
+        for (ConnectionAcquiringListener listener : listeners) {
+            listener.afterAcquireConnection(connectionInfo, elapsedTime, throwable);
+        }
+    }
+
+    @Override
+    public void afterCommitConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable) {
+        for (ConnectionAcquiringListener listener : listeners) {
+            listener.afterCommitConnection(connectionInfo, elapsedTime, throwable);
+        }
+    }
+
+    @Override
+    public void afterRollbackConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable) {
+        for (ConnectionAcquiringListener listener : listeners) {
+            listener.afterRollbackConnection(connectionInfo, elapsedTime, throwable);
+        }
+    }
+
+    @Override
+    public void afterCloseConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable) {
+        for (ConnectionAcquiringListener listener : listeners) {
+            listener.afterCloseConnection(connectionInfo, elapsedTime, throwable);
+        }
+    }
+
+    public void addListener(ConnectionAcquiringListener listener) {
+        this.listeners.add(listener);
+    }
+
+    public List<ConnectionAcquiringListener> getListeners() {
+        return Collections.unmodifiableList(listeners);
+    }
+
+    public void setListeners(List<ConnectionAcquiringListener> listeners) {
+        this.listeners = listeners;
+    }
+}

--- a/src/main/java/net/ttddyy/dsproxy/listener/ConnectionAcquiringListener.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/ConnectionAcquiringListener.java
@@ -1,0 +1,16 @@
+package net.ttddyy.dsproxy.listener;
+
+import net.ttddyy.dsproxy.ConnectionInfo;
+
+public interface ConnectionAcquiringListener {
+
+    void beforeAcquireConnection(ConnectionInfo connectionInfo);
+
+    void afterAcquireConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable);
+
+    void afterCommitConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable);
+
+    void afterRollbackConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable);
+
+    void afterCloseConnection(ConnectionInfo connectionInfo, long elapsedTime, Throwable throwable);
+}

--- a/src/main/java/net/ttddyy/dsproxy/proxy/InterceptorHolder.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/InterceptorHolder.java
@@ -1,6 +1,8 @@
 package net.ttddyy.dsproxy.proxy;
 
+import net.ttddyy.dsproxy.listener.ChainConnectionAcquiringListener;
 import net.ttddyy.dsproxy.listener.ChainListener;
+import net.ttddyy.dsproxy.listener.ConnectionAcquiringListener;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
 import net.ttddyy.dsproxy.transform.ParameterTransformer;
 import net.ttddyy.dsproxy.transform.QueryTransformer;
@@ -17,6 +19,7 @@ import net.ttddyy.dsproxy.transform.QueryTransformer;
 public class InterceptorHolder {
 
     private ChainListener chainListener = new ChainListener();  // empty default
+    private ChainConnectionAcquiringListener chainConnectionAcquiringListener = new ChainConnectionAcquiringListener();  // empty default
     private QueryTransformer queryTransformer = QueryTransformer.DEFAULT;
     private ParameterTransformer parameterTransformer = ParameterTransformer.DEFAULT;
 
@@ -38,6 +41,10 @@ public class InterceptorHolder {
         return this.chainListener;
     }
 
+    public ConnectionAcquiringListener getConnectionAcquiringListener() {
+        return this.chainConnectionAcquiringListener;
+    }
+
     public void setListener(QueryExecutionListener listener) {
         if (listener instanceof ChainListener) {
             this.chainListener = (ChainListener) listener;
@@ -54,6 +61,15 @@ public class InterceptorHolder {
      */
     public void addListener(QueryExecutionListener listener) {
         this.chainListener.addListener(listener);
+    }
+
+    /**
+     * Add {@link ConnectionAcquiringListener}
+     *
+     * @param listener a query execution listener
+     */
+    public void addConnectionAcquiringListener(ConnectionAcquiringListener listener) {
+        this.chainConnectionAcquiringListener.addListener(listener);
     }
 
     public QueryTransformer getQueryTransformer() {

--- a/src/main/java/net/ttddyy/dsproxy/support/ProxyDataSourceBuilder.java
+++ b/src/main/java/net/ttddyy/dsproxy/support/ProxyDataSourceBuilder.java
@@ -1,6 +1,7 @@
 package net.ttddyy.dsproxy.support;
 
 import net.ttddyy.dsproxy.ConnectionIdManager;
+import net.ttddyy.dsproxy.listener.ConnectionAcquiringListener;
 import net.ttddyy.dsproxy.listener.DataSourceQueryCountListener;
 import net.ttddyy.dsproxy.listener.QueryCountStrategy;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
@@ -87,6 +88,7 @@ public class ProxyDataSourceBuilder {
     private boolean jsonFormat;
     private boolean multiline;
     private List<QueryExecutionListener> queryExecutionListeners = new ArrayList<QueryExecutionListener>();
+    private List<ConnectionAcquiringListener> connectionAcquiringListeners = new ArrayList<ConnectionAcquiringListener>();
 
     private ParameterTransformer parameterTransformer;
     private QueryTransformer queryTransformer;
@@ -491,6 +493,17 @@ public class ProxyDataSourceBuilder {
     }
 
     /**
+     * Register given listener.
+     *
+     * @param listener a listener to register
+     * @return builder
+     */
+    public ProxyDataSourceBuilder connectionAcquiringListener(ConnectionAcquiringListener listener) {
+        this.connectionAcquiringListeners.add(listener);
+        return this;
+    }
+
+    /**
      * Format logging output as JSON.
      *
      * @return builder
@@ -629,6 +642,10 @@ public class ProxyDataSourceBuilder {
 
         for (QueryExecutionListener listener : listeners) {
             proxyDataSource.addListener(listener);
+        }
+
+        for (ConnectionAcquiringListener listener : connectionAcquiringListeners) {
+            proxyDataSource.addConnectionAcquiringListener(listener);
         }
 
         if (this.queryTransformer != null) {

--- a/src/test/java/net/ttddyy/dsproxy/support/ProxyDataSourceBuilderTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/support/ProxyDataSourceBuilderTest.java
@@ -1,7 +1,9 @@
 package net.ttddyy.dsproxy.support;
 
 import net.ttddyy.dsproxy.ConnectionIdManager;
+import net.ttddyy.dsproxy.listener.ChainConnectionAcquiringListener;
 import net.ttddyy.dsproxy.listener.ChainListener;
+import net.ttddyy.dsproxy.listener.ConnectionAcquiringListener;
 import net.ttddyy.dsproxy.listener.DataSourceQueryCountListener;
 import net.ttddyy.dsproxy.listener.QueryCountStrategy;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
@@ -22,6 +24,7 @@ import net.ttddyy.dsproxy.listener.logging.SystemOutQueryLoggingListener;
 import net.ttddyy.dsproxy.listener.logging.SystemOutSlowQueryListener;
 import net.ttddyy.dsproxy.proxy.JdbcProxyFactory;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -336,6 +339,25 @@ public class ProxyDataSourceBuilderTest {
         assertThat(listener.getQueryCountStrategy()).as("count listener with strategy")
                 .isNotNull()
                 .isSameAs(strategy);
+    }
+
+    @Test
+    public void customQueryExecutionListener() {
+        QueryExecutionListener queryExecutionListener = Mockito.mock(QueryExecutionListener.class);
+        ProxyDataSource ds = ProxyDataSourceBuilder.create().listener(queryExecutionListener).build();
+
+        ChainListener chainListener = (ChainListener) ds.getInterceptorHolder().getListener();
+        assertThat(chainListener.getListeners().get(0)).isSameAs(queryExecutionListener);
+    }
+
+    @Test
+    public void customConnectionAcquiringListener() {
+        ConnectionAcquiringListener connectionAcquiringListener = Mockito.mock(ConnectionAcquiringListener.class);
+        ProxyDataSource ds = ProxyDataSourceBuilder.create().connectionAcquiringListener(connectionAcquiringListener).build();
+
+        ChainConnectionAcquiringListener chainListener =
+                (ChainConnectionAcquiringListener) ds.getInterceptorHolder().getConnectionAcquiringListener();
+        assertThat(chainListener.getListeners().get(0)).isSameAs(connectionAcquiringListener);
     }
 
 }


### PR DESCRIPTION
Hi, as you suggested to add some additinal callbacks to datasource-proxy I would like to introduce listener to the Connection operations.

ConnectionAcquiringListener reacts on next events:
* `beforeAcquireConnection` - before `DataSource#getConnection`
* `afterAcquireConnection` - after `DataSource#getConnection`, including acquire time and exception if thown while getting connection.
* `afterCommitConnection` - after `Connection#commit`, including commit time and exception if thown while committing.
* `afterRollbackConnection` - after `Connection#rollback`, including rollback time and exception if thown while rolling back.
* `afterCloseConnection` - after `Connection#close`, including close time and exception if thown while closing.

I didn't include `before*` for commit/rollback/close as they seem useless, although time for waiting on `DataSource#getConnection` may be significant if connection pool has no free connections and wait time is limited to a huge number. If you think otherwise it is not a big deal to add them.

Expecting change requests from you I didn't add a documentation/license/since tag, I will do it once you approve the api.