### PR TITLE
Add Isolation level in query logs

### DIFF
--- a/src/main/java/net/ttddyy/dsproxy/ConnectionInfo.java
+++ b/src/main/java/net/ttddyy/dsproxy/ConnectionInfo.java
@@ -10,6 +10,7 @@ public class ConnectionInfo {
 
     private String dataSourceName;
     private String connectionId;
+    private int isolationLevel;
     private boolean isClosed;
     private int commitCount;
     private int rollbackCount;
@@ -28,6 +29,14 @@ public class ConnectionInfo {
 
     public void setConnectionId(String connectionId) {
         this.connectionId = connectionId;
+    }
+
+    public int getIsolationLevel() {
+        return isolationLevel;
+    }
+
+    public void setIsolationLevel(int isolationLevel) {
+        this.isolationLevel = isolationLevel;
     }
 
     /**

--- a/src/main/java/net/ttddyy/dsproxy/ExecutionInfo.java
+++ b/src/main/java/net/ttddyy/dsproxy/ExecutionInfo.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public class ExecutionInfo {
     private String dataSourceName;
     private String connectionId;
+    private int isolationLevel;
     private Method method;
     private Object[] methodArgs;
     private Object result;
@@ -33,6 +34,7 @@ public class ExecutionInfo {
     public ExecutionInfo(ConnectionInfo connectionInfo, Statement statement, boolean isBatch, int batchSize, Method method, Object[] methodArgs) {
         this.dataSourceName = connectionInfo.getDataSourceName();
         this.connectionId = connectionInfo.getConnectionId();
+        this.isolationLevel = connectionInfo.getIsolationLevel();
         this.statement = statement;
         this.isBatch = isBatch;
         this.batchSize = batchSize;
@@ -78,6 +80,20 @@ public class ExecutionInfo {
      */
     public void setConnectionId(String connectionId) {
         this.connectionId = connectionId;
+    }
+
+    /**
+     * @since 1.8
+     */
+    public int getIsolationLevel() {
+        return isolationLevel;
+    }
+
+    /**
+     * @since 1.8
+     */
+    public void setIsolationLevel(int isolationLevel) {
+        this.isolationLevel = isolationLevel;
     }
 
     /**

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLogEntryCreator.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLogEntryCreator.java
@@ -3,6 +3,7 @@ package net.ttddyy.dsproxy.listener.logging;
 import net.ttddyy.dsproxy.StatementType;
 import net.ttddyy.dsproxy.proxy.ParameterSetOperation;
 
+import java.sql.Connection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -67,6 +68,22 @@ public abstract class AbstractQueryLogEntryCreator implements QueryLogEntryCreat
         if (sb.charAt(lastCharIndex) == c) {
             sb.deleteCharAt(lastCharIndex);
         }
+    }
+
+    protected String getTransactionIsolation(int isolationLevel) {
+        switch (isolationLevel) {
+            case Connection.TRANSACTION_NONE:
+                return "NONE";
+            case Connection.TRANSACTION_READ_UNCOMMITTED:
+                return "READ_UNCOMMITTED";
+            case Connection.TRANSACTION_READ_COMMITTED:
+                return "READ_COMMITTED";
+            case Connection.TRANSACTION_REPEATABLE_READ:
+                return "REPEATABLE_READ";
+            case Connection.TRANSACTION_SERIALIZABLE:
+                return "SERIALIZABLE";
+        }
+        return "";
     }
 
     protected String getStatementType(StatementType statementType) {

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLoggingListener.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLoggingListener.java
@@ -15,6 +15,7 @@ public abstract class AbstractQueryLoggingListener implements QueryExecutionList
     protected QueryLogEntryCreator queryLogEntryCreator = new DefaultQueryLogEntryCreator();
     protected boolean writeDataSourceName = true;
     protected boolean writeConnectionId = true;
+    protected boolean writeIsolation = true;
     protected LoggingCondition loggingCondition;
 
     @Override
@@ -31,7 +32,7 @@ public abstract class AbstractQueryLoggingListener implements QueryExecutionList
     }
 
     protected String getEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
-        return this.queryLogEntryCreator.getLogEntry(execInfo, queryInfoList, this.writeDataSourceName, this.writeConnectionId);
+        return this.queryLogEntryCreator.getLogEntry(execInfo, queryInfoList, this.writeDataSourceName, this.writeConnectionId, this.writeIsolation);
     }
 
     protected abstract void writeLog(String message);
@@ -80,6 +81,13 @@ public abstract class AbstractQueryLoggingListener implements QueryExecutionList
      */
     public void setWriteConnectionId(boolean writeConnectionId) {
         this.writeConnectionId = writeConnectionId;
+    }
+
+    /**
+     * @since 1.8
+     */
+    public void setWriteIsolation(boolean writeIsolation) {
+        this.writeIsolation = writeIsolation;
     }
 
     /**

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractSlowQueryLoggingListener.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractSlowQueryLoggingListener.java
@@ -18,12 +18,13 @@ public abstract class AbstractSlowQueryLoggingListener extends SlowQueryListener
 
     protected boolean writeDataSourceName = true;
     protected boolean writeConnectionId = true;
+    protected boolean writeIsolation = true;
     protected QueryLogEntryCreator queryLogEntryCreator = new DefaultQueryLogEntryCreator();
     protected String prefix;
 
     @Override
     protected void onSlowQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, long startTimeInMills) {
-        String entry = this.queryLogEntryCreator.getLogEntry(execInfo, queryInfoList, this.writeDataSourceName, this.writeConnectionId);
+        String entry = this.queryLogEntryCreator.getLogEntry(execInfo, queryInfoList, this.writeDataSourceName, this.writeConnectionId, this.writeIsolation);
         if (this.prefix != null) {
             StringBuilder sb = new StringBuilder();
             sb.append(this.prefix);
@@ -56,5 +57,12 @@ public abstract class AbstractSlowQueryLoggingListener extends SlowQueryListener
      */
     public void setWriteConnectionId(boolean writeConnectionId) {
         this.writeConnectionId = writeConnectionId;
+    }
+
+    /**
+     * @since 1.8
+     */
+    public void setWriteIsolation(boolean writeIsolation) {
+        this.writeIsolation = writeIsolation;
     }
 }

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/DefaultJsonQueryLogEntryCreator.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/DefaultJsonQueryLogEntryCreator.java
@@ -18,7 +18,7 @@ import java.util.SortedMap;
 public class DefaultJsonQueryLogEntryCreator extends AbstractQueryLogEntryCreator {
 
     @Override
-    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId) {
+    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId, boolean writeIsolation) {
         StringBuilder sb = new StringBuilder();
 
         sb.append("{");
@@ -30,6 +30,9 @@ public class DefaultJsonQueryLogEntryCreator extends AbstractQueryLogEntryCreato
             writeConnectionIdEntry(sb, execInfo, queryInfoList);
         }
 
+        if(writeIsolation) {
+            writeIsolationEntry(sb, execInfo, queryInfoList);
+        }
 
         // Time
         writeTimeEntry(sb, execInfo, queryInfoList);
@@ -88,6 +91,22 @@ public class DefaultJsonQueryLogEntryCreator extends AbstractQueryLogEntryCreato
         sb.append("\"connection\":");
         sb.append(execInfo.getConnectionId());
         sb.append(", ");
+    }
+
+    /**
+     * Write transaction isolation when enabled as json.
+     *
+     * <p>default: "isolation":"READ_COMMITTED",
+     *
+     * @param sb            StringBuilder to write
+     * @param execInfo      execution info
+     * @param queryInfoList query info list
+     * @since 1.8
+     */
+    protected void writeIsolationEntry(StringBuilder sb, ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        sb.append("\"isolation\":\"");
+        sb.append(getTransactionIsolation(execInfo.getIsolationLevel()));
+        sb.append("\", ");
     }
 
     /**

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/DefaultQueryLogEntryCreator.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/DefaultQueryLogEntryCreator.java
@@ -20,7 +20,7 @@ public class DefaultQueryLogEntryCreator extends AbstractQueryLogEntryCreator {
     private boolean multiline = false;
 
     @Override
-    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId) {
+    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId, boolean writeIsolation) {
         final StringBuilder sb = new StringBuilder();
 
         if (this.multiline) {
@@ -33,6 +33,10 @@ public class DefaultQueryLogEntryCreator extends AbstractQueryLogEntryCreator {
 
         if (writeConnectionId) {
             writeConnectionIdEntry(sb, execInfo, queryInfoList);
+        }
+
+        if(writeIsolation) {
+            writeIsolationEntry(sb, execInfo, queryInfoList);
         }
 
         // Time
@@ -107,6 +111,22 @@ public class DefaultQueryLogEntryCreator extends AbstractQueryLogEntryCreator {
     protected void writeConnectionIdEntry(StringBuilder sb, ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
         sb.append("Connection:");
         sb.append(execInfo.getConnectionId());
+        sb.append(", ");
+    }
+
+    /**
+     * Write transaction isolation when enabled.
+     *
+     * <p>default: Isolation: READ_COMMITTED,
+     *
+     * @param sb            StringBuilder to write
+     * @param execInfo      execution info
+     * @param queryInfoList query info list
+     * @since 1.8
+     */
+    protected void writeIsolationEntry(StringBuilder sb, ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        sb.append("Isolation:");
+        sb.append(getTransactionIsolation(execInfo.getIsolationLevel()));
         sb.append(", ");
     }
 

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/OutputParameterJsonLogEntryCreator.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/OutputParameterJsonLogEntryCreator.java
@@ -18,9 +18,9 @@ import java.util.List;
 public class OutputParameterJsonLogEntryCreator extends DefaultJsonQueryLogEntryCreator {
 
     @Override
-    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId) {
+    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId, boolean writeIsolation) {
         final StringBuilder sb = new StringBuilder();
-        sb.append(super.getLogEntry(execInfo, queryInfoList, writeDataSourceName, writeConnectionId));
+        sb.append(super.getLogEntry(execInfo, queryInfoList, writeDataSourceName, writeConnectionId, writeIsolation));
 
         chompIfEndWith(sb, '}');  // hack to remove closing curly bracket from returned json string
 

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/OutputParameterLogEntryCreator.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/OutputParameterLogEntryCreator.java
@@ -18,9 +18,9 @@ import java.util.List;
 public class OutputParameterLogEntryCreator extends DefaultQueryLogEntryCreator {
 
     @Override
-    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId) {
+    public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId, boolean writeIsolation) {
         final StringBuilder sb = new StringBuilder();
-        sb.append(super.getLogEntry(execInfo, queryInfoList, writeDataSourceName, writeConnectionId));
+        sb.append(super.getLogEntry(execInfo, queryInfoList, writeDataSourceName, writeConnectionId, writeIsolation));
 
         sb.append(", OutParams:[");
 

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/QueryLogEntryCreator.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/QueryLogEntryCreator.java
@@ -13,6 +13,6 @@ import java.util.List;
  */
 public interface QueryLogEntryCreator {
 
-    String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId);
+    String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId, boolean writeIsolation);
 
 }

--- a/src/main/java/net/ttddyy/dsproxy/proxy/ConnectionProxyLogic.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/ConnectionProxyLogic.java
@@ -85,6 +85,10 @@ public class ConnectionProxyLogic {
             return this.connection;
         }
 
+        if("setTransactionIsolation".equals(methodName)) {
+            connectionInfo.setIsolationLevel((Integer) args[0]);
+        }
+
         if (JDBC4_METHODS.contains(methodName)) {
             final Class<?> clazz = (Class<?>) args[0];
             if ("unwrap".equals(methodName)) {

--- a/src/main/java/net/ttddyy/dsproxy/proxy/DataSourceProxyLogic.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/DataSourceProxyLogic.java
@@ -84,6 +84,7 @@ public class DataSourceProxyLogic {
                 String connId = connectionIdManager.getId(conn);
                 ConnectionInfo connectionInfo = new ConnectionInfo();
                 connectionInfo.setConnectionId(connId);
+                connectionInfo.setIsolationLevel(conn.getTransactionIsolation());
                 connectionInfo.setDataSourceName(dataSourceName);
 
                 return jdbcProxyFactory.createConnection((Connection) retVal, connectionInfo, this.proxyConfig);

--- a/src/main/java/net/ttddyy/dsproxy/support/ProxyConnectionAdvice.java
+++ b/src/main/java/net/ttddyy/dsproxy/support/ProxyConnectionAdvice.java
@@ -31,6 +31,7 @@ public class ProxyConnectionAdvice implements MethodInterceptor {
         String connId = this.proxyConfig.getConnectionIdManager().getId(conn);
         ConnectionInfo connectionInfo = new ConnectionInfo();
         connectionInfo.setConnectionId(connId);
+        connectionInfo.setIsolationLevel(conn.getTransactionIsolation());
         connectionInfo.setDataSourceName("");
 
         return this.proxyConfig.getJdbcProxyFactory().createConnection((Connection) retVal, connectionInfo, this.proxyConfig);

--- a/src/main/java/net/ttddyy/dsproxy/support/ProxyDataSource.java
+++ b/src/main/java/net/ttddyy/dsproxy/support/ProxyDataSource.java
@@ -88,6 +88,7 @@ public class ProxyDataSource implements DataSource, Closeable {
 
         final ConnectionInfo connectionInfo = new ConnectionInfo();
         connectionInfo.setConnectionId(connectionId);
+        connectionInfo.setIsolationLevel(conn.getTransactionIsolation());
         connectionInfo.setDataSourceName(dataSourceName);
 
         try {

--- a/src/test/java/net/ttddyy/dsproxy/ExecutionInfoBuilder.java
+++ b/src/test/java/net/ttddyy/dsproxy/ExecutionInfoBuilder.java
@@ -18,6 +18,7 @@ public class ExecutionInfoBuilder {
     private boolean batch;
     private int batchSize;
     private String connectionId;
+    private int isolationLevel;
 
     public static ExecutionInfoBuilder create() {
         return new ExecutionInfoBuilder();
@@ -78,6 +79,11 @@ public class ExecutionInfoBuilder {
         return this;
     }
 
+    public ExecutionInfoBuilder isolationLevel(int isolationLevel) {
+        this.isolationLevel = isolationLevel;
+        return this;
+    }
+
     public ExecutionInfo build() {
         ExecutionInfo executionInfo = new ExecutionInfo();
         executionInfo.setDataSourceName(dataSourceName);
@@ -91,6 +97,7 @@ public class ExecutionInfoBuilder {
         executionInfo.setBatch(batch);
         executionInfo.setBatchSize(batchSize);
         executionInfo.setConnectionId(this.connectionId);
+        executionInfo.setIsolationLevel(isolationLevel);
         return executionInfo;
     }
 }

--- a/src/test/java/net/ttddyy/dsproxy/listener/SlowQueryListenerTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/listener/SlowQueryListenerTest.java
@@ -93,9 +93,9 @@ public class SlowQueryListenerTest {
         final AtomicLong executionTime = new AtomicLong(0);
         QueryLogEntryCreator queryLogEntryCreator = new DefaultQueryLogEntryCreator() {
             @Override
-            public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId) {
+            public String getLogEntry(ExecutionInfo execInfo, List<QueryInfo> queryInfoList, boolean writeDataSourceName, boolean writeConnectionId, boolean writeIsolation) {
                 executionTime.set(execInfo.getElapsedTime());
-                return super.getLogEntry(execInfo, queryInfoList, writeDataSourceName, writeConnectionId);
+                return super.getLogEntry(execInfo, queryInfoList, writeDataSourceName, writeConnectionId, writeIsolation);
             }
         };
 

--- a/src/test/java/net/ttddyy/dsproxy/listener/logging/DefaultJsonQueryLogEntryCreatorTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/listener/logging/DefaultJsonQueryLogEntryCreatorTest.java
@@ -9,6 +9,7 @@ import org.assertj.core.util.Lists;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -28,6 +29,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -41,19 +43,23 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
 
         // writeDataSourceName=false
-        jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true);
-        assertThat(jsonEntry).isEqualTo("{\"connection\":10, \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
+        jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true, true);
+        assertThat(jsonEntry).isEqualTo("{\"connection\":10, \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
 
         // writeConnectionId=false
-        jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, false);
-        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
+        jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, false, true);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
 
-        // writeDataSourceName=false, writeConnectionId=false
-        jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, false);
+        // writeIsolation=false
+        jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, false);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
+
+        // writeDataSourceName=false, writeConnectionId=false, writeIsolation=false
+        jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, false, false);
         assertThat(jsonEntry).isEqualTo("{\"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{}]}");
     }
 
@@ -66,6 +72,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -80,8 +87,8 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo1, queryInfo2), true, true);
-        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":true, \"querySize\":2, \"batchSize\":2, \"query\":[\"select 1\",\"select 2\"], \"params\":[{},{}]}");
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo1, queryInfo2), true, true, true);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Statement\", \"batch\":true, \"querySize\":2, \"batchSize\":2, \"query\":[\"select 1\",\"select 2\"], \"params\":[{},{}]}");
     }
 
     @Test
@@ -93,6 +100,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -111,8 +119,8 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"time\":100, \"success\":true, \"type\":\"Prepared\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[[\"foo\",\"100\",null]]}");
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Prepared\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[[\"foo\",\"100\",null]]}");
     }
 
     @Test
@@ -124,6 +132,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -143,8 +152,8 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"time\":100, \"success\":true, \"type\":\"Prepared\", \"batch\":true, \"querySize\":1, \"batchSize\":2, \"query\":[\"select 1\"], \"params\":[[\"foo\",\"100\"],[\"bar\",\"200\"]]}");
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Prepared\", \"batch\":true, \"querySize\":1, \"batchSize\":2, \"query\":[\"select 1\"], \"params\":[[\"foo\",\"100\"],[\"bar\",\"200\"]]}");
     }
 
     @Test
@@ -156,6 +165,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -173,8 +183,8 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"time\":100, \"success\":true, \"type\":\"Callable\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{\"id\":\"100\",\"name\":\"foo\"}]}");
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Callable\", \"batch\":false, \"querySize\":1, \"batchSize\":0, \"query\":[\"select 1\"], \"params\":[{\"id\":\"100\",\"name\":\"foo\"}]}");
     }
 
     @Test
@@ -186,6 +196,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -205,8 +216,8 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"time\":100, \"success\":true, \"type\":\"Callable\", \"batch\":true, \"querySize\":1, \"batchSize\":2, \"query\":[\"select 1\"], \"params\":[{\"id\":\"100\",\"name\":\"foo\"},{\"id\":\"200\",\"name\":\"bar\"}]}");
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(jsonEntry).isEqualTo("{\"name\":\"foo\", \"connection\":10, \"isolation\":\"READ_COMMITTED\", \"time\":100, \"success\":true, \"type\":\"Callable\", \"batch\":true, \"querySize\":1, \"batchSize\":2, \"query\":[\"select 1\"], \"params\":[{\"id\":\"100\",\"name\":\"foo\"},{\"id\":\"200\",\"name\":\"bar\"}]}");
     }
 
     @Test
@@ -218,6 +229,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -239,7 +251,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(jsonEntry).containsOnlyOnce("\"params\":[[\"foo\",\"100\",\"FOO\"],[\"bar\",\"200\",\"BAR\"]]");
     }
 
@@ -252,6 +264,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -273,7 +286,7 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         DefaultJsonQueryLogEntryCreator creator = new DefaultJsonQueryLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(jsonEntry).containsOnlyOnce("\"params\":[{\"a-idx\":\"foo\",\"b-idx\":\"FOO\",\"c-idx\":\"100\"},{\"a-idx\":\"bar\",\"b-idx\":\"BAR\",\"c-idx\":\"200\"}]");
     }
 
@@ -286,17 +299,17 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         // Statement
         executionInfo = ExecutionInfoBuilder.create().statementType(StatementType.STATEMENT).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"type\":\"Statement\"");
 
         // PreparedStatement
         executionInfo = ExecutionInfoBuilder.create().statementType(StatementType.PREPARED).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"type\":\"Prepared\"");
 
         // CallableStatement
         executionInfo = ExecutionInfoBuilder.create().statementType(StatementType.CALLABLE).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"type\":\"Callable\"");
     }
 
@@ -311,11 +324,11 @@ public class DefaultJsonQueryLogEntryCreatorTest {
         String jsonResult;
 
         // single query
-        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"query\":[\"select 1\"]");
 
         // multiple query
-        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"query\":[\"select 1\",\"select 2\",\"select 3\"]");
     }
 
@@ -330,11 +343,11 @@ public class DefaultJsonQueryLogEntryCreatorTest {
         String jsonResult;
 
         // single query
-        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"querySize\":1");
 
         // multiple query
-        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"querySize\":3");
     }
 
@@ -347,12 +360,12 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         // success
         executionInfo = ExecutionInfoBuilder.create().success(true).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"success\":true");
 
         // fail
         executionInfo = ExecutionInfoBuilder.create().success(false).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"success\":false");
 
     }
@@ -366,12 +379,12 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         // success
         executionInfo = ExecutionInfoBuilder.create().batch(true).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"batch\":true");
 
         // fail
         executionInfo = ExecutionInfoBuilder.create().batch(false).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"batch\":false");
     }
 
@@ -384,11 +397,11 @@ public class DefaultJsonQueryLogEntryCreatorTest {
 
         // default
         executionInfo = ExecutionInfoBuilder.create().build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"batchSize\":0");
 
         executionInfo = ExecutionInfoBuilder.create().batchSize(100).build();
-        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        jsonResult = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(jsonResult).containsOnlyOnce("\"batchSize\":100");
     }
 

--- a/src/test/java/net/ttddyy/dsproxy/listener/logging/DefaultQueryLogEntryCreatorTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/listener/logging/DefaultQueryLogEntryCreatorTest.java
@@ -9,6 +9,7 @@ import org.assertj.core.util.Lists;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -30,6 +31,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -43,27 +45,31 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(entry).isEqualTo("Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Statement, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[()]");
+
+        //writeIsolation=false
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, false);
         assertThat(entry).isEqualTo("Name:foo, Connection:10, Time:100, Success:True, Type:Statement, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[()]");
 
         // writeDataSourceName=false
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true);
-        assertThat(entry).isEqualTo("Connection:10, Time:100, Success:True, Type:Statement, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[()]");
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true, true);
+        assertThat(entry).isEqualTo("Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Statement, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[()]");
 
         // writeConnectionId=false
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, false);
-        assertThat(entry).isEqualTo("Name:foo, Time:100, Success:True, Type:Statement, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[()]");
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, false, true);
+        assertThat(entry).isEqualTo("Name:foo, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Statement, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[()]");
 
-        // writeDataSourceName=false, writeConnectionId=false
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, false);
+        // writeDataSourceName=false, writeConnectionId=false, writeIsolation=false
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, false, false);
         assertThat(entry).isEqualTo("Time:100, Success:True, Type:Statement, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[()]");
 
         // check multiline
         creator.setMultiline(true);
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(entry).isEqualTo(
                 "" + LINE_SEPARATOR +
-                        "Name:foo, Connection:10, Time:100, Success:True" + LINE_SEPARATOR +
+                        "Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True" + LINE_SEPARATOR +
                         "Type:Statement, Batch:False, QuerySize:1, BatchSize:0" + LINE_SEPARATOR +
                         "Query:[\"select 1\"]" + LINE_SEPARATOR +
                         "Params:[()]");
@@ -79,6 +85,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -93,15 +100,15 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo1, queryInfo2), true, true);
-        assertThat(entry).isEqualTo("Name:foo, Connection:10, Time:100, Success:True, Type:Statement, Batch:True, QuerySize:2, BatchSize:2, Query:[\"select 1\",\"select 2\"], Params:[(),()]");
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo1, queryInfo2), true, true, true);
+        assertThat(entry).isEqualTo("Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Statement, Batch:True, QuerySize:2, BatchSize:2, Query:[\"select 1\",\"select 2\"], Params:[(),()]");
 
         // check multiline
         creator.setMultiline(true);
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo1, queryInfo2), true, true);
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo1, queryInfo2), true, true, true);
         assertThat(entry).isEqualTo(
                 "" + LINE_SEPARATOR +
-                        "Name:foo, Connection:10, Time:100, Success:True" + LINE_SEPARATOR +
+                        "Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True" + LINE_SEPARATOR +
                         "Type:Statement, Batch:True, QuerySize:2, BatchSize:2" + LINE_SEPARATOR +
                         "Query:[\"select 1\",\"select 2\"]" + LINE_SEPARATOR +
                         "Params:[(),()]");
@@ -117,6 +124,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -135,15 +143,15 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(entry).isEqualTo("Name:foo, Connection:10, Time:100, Success:True, Type:Prepared, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[(foo,100,null)]");
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(entry).isEqualTo("Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Prepared, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[(foo,100,null)]");
 
         // check multiline
         creator.setMultiline(true);
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(entry).isEqualTo(
                 "" + LINE_SEPARATOR +
-                        "Name:foo, Connection:10, Time:100, Success:True" + LINE_SEPARATOR +
+                        "Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True" + LINE_SEPARATOR +
                         "Type:Prepared, Batch:False, QuerySize:1, BatchSize:0" + LINE_SEPARATOR +
                         "Query:[\"select 1\"]" + LINE_SEPARATOR +
                         "Params:[(foo,100,null)]");
@@ -159,6 +167,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -178,15 +187,15 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(entry).isEqualTo("Name:foo, Connection:10, Time:100, Success:True, Type:Prepared, Batch:True, QuerySize:1, BatchSize:2, Query:[\"select 1\"], Params:[(foo,100),(bar,200)]");
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(entry).isEqualTo("Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Prepared, Batch:True, QuerySize:1, BatchSize:2, Query:[\"select 1\"], Params:[(foo,100),(bar,200)]");
 
         // check multiline
         creator.setMultiline(true);
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(entry).isEqualTo(
                 "" + LINE_SEPARATOR +
-                        "Name:foo, Connection:10, Time:100, Success:True" + LINE_SEPARATOR +
+                        "Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True" + LINE_SEPARATOR +
                         "Type:Prepared, Batch:True, QuerySize:1, BatchSize:2" + LINE_SEPARATOR +
                         "Query:[\"select 1\"]" + LINE_SEPARATOR +
                         "Params:[(foo,100),(bar,200)]");
@@ -201,6 +210,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -218,15 +228,15 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(entry).isEqualTo("Name:foo, Connection:10, Time:100, Success:True, Type:Callable, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[(id=100,name=foo)]");
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(entry).isEqualTo("Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Callable, Batch:False, QuerySize:1, BatchSize:0, Query:[\"select 1\"], Params:[(id=100,name=foo)]");
 
         // check multiline
         creator.setMultiline(true);
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(entry).isEqualTo(
                 "" + LINE_SEPARATOR +
-                        "Name:foo, Connection:10, Time:100, Success:True" + LINE_SEPARATOR +
+                        "Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True" + LINE_SEPARATOR +
                         "Type:Callable, Batch:False, QuerySize:1, BatchSize:0" + LINE_SEPARATOR +
                         "Query:[\"select 1\"]" + LINE_SEPARATOR +
                         "Params:[(id=100,name=foo)]");
@@ -242,6 +252,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -261,15 +272,15 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
-        assertThat(entry).isEqualTo("Name:foo, Connection:10, Time:100, Success:True, Type:Callable, Batch:True, QuerySize:1, BatchSize:2, Query:[\"select 1\"], Params:[(id=100,name=foo),(id=200,name=bar)]");
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
+        assertThat(entry).isEqualTo("Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True, Type:Callable, Batch:True, QuerySize:1, BatchSize:2, Query:[\"select 1\"], Params:[(id=100,name=foo),(id=200,name=bar)]");
 
         // check multiline
         creator.setMultiline(true);
-        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(entry).isEqualTo(
                 "" + LINE_SEPARATOR +
-                        "Name:foo, Connection:10, Time:100, Success:True" + LINE_SEPARATOR +
+                        "Name:foo, Connection:10, Isolation:READ_COMMITTED, Time:100, Success:True" + LINE_SEPARATOR +
                         "Type:Callable, Batch:True, QuerySize:1, BatchSize:2" + LINE_SEPARATOR +
                         "Query:[\"select 1\"]" + LINE_SEPARATOR +
                         "Params:[(id=100,name=foo),(id=200,name=bar)]");
@@ -284,6 +295,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -305,7 +317,7 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(entry).containsOnlyOnce("Params:[(foo,100,FOO),(bar,200,BAR)]");
 
     }
@@ -319,6 +331,7 @@ public class DefaultQueryLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .connectionId("10")
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .elapsedTime(100)
                 .method(method)
                 .result(result)
@@ -340,7 +353,7 @@ public class DefaultQueryLogEntryCreatorTest {
 
         DefaultQueryLogEntryCreator creator = new DefaultQueryLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true);
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), true, true, true);
         assertThat(entry).containsOnlyOnce("Params:[(a-idx=foo,b-idx=FOO,c-idx=100),(a-idx=bar,b-idx=BAR,c-idx=200)]");
 
     }
@@ -354,17 +367,17 @@ public class DefaultQueryLogEntryCreatorTest {
 
         // Statement
         executionInfo = ExecutionInfoBuilder.create().statementType(StatementType.STATEMENT).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("Type:Statement");
 
         // PreparedStatement
         executionInfo = ExecutionInfoBuilder.create().statementType(StatementType.PREPARED).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("Type:Prepared");
 
         // CallableStatement
         executionInfo = ExecutionInfoBuilder.create().statementType(StatementType.CALLABLE).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("Type:Callable");
     }
 
@@ -379,11 +392,11 @@ public class DefaultQueryLogEntryCreatorTest {
         String result;
 
         // single query
-        result = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true);
+        result = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true, true);
         assertThat(result).containsOnlyOnce("Query:[\"select 1\"]");
 
         // multiple query
-        result = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true);
+        result = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true, true);
         assertThat(result).containsOnlyOnce("Query:[\"select 1\",\"select 2\",\"select 3\"]");
     }
 
@@ -399,7 +412,7 @@ public class DefaultQueryLogEntryCreatorTest {
             }
         };
 
-        String result = creator.getLogEntry(executionInfo, Arrays.asList(select), true, true);
+        String result = creator.getLogEntry(executionInfo, Arrays.asList(select), true, true, true);
         assertThat(result).containsOnlyOnce("Query:[\"select 1 formatted\"]");
     }
 
@@ -414,11 +427,11 @@ public class DefaultQueryLogEntryCreatorTest {
         String result;
 
         // single query
-        result = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true);
+        result = creator.getLogEntry(executionInfo, Arrays.asList(select1), true, true, true);
         assertThat(result).containsOnlyOnce("QuerySize:1");
 
         // multiple query
-        result = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true);
+        result = creator.getLogEntry(executionInfo, Arrays.asList(select1, select2, select3), true, true, true);
         assertThat(result).containsOnlyOnce("QuerySize:3");
     }
 
@@ -431,12 +444,12 @@ public class DefaultQueryLogEntryCreatorTest {
 
         // success
         executionInfo = ExecutionInfoBuilder.create().success(true).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("Success:True");
 
         // fail
         executionInfo = ExecutionInfoBuilder.create().success(false).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("Success:False");
 
     }
@@ -450,12 +463,12 @@ public class DefaultQueryLogEntryCreatorTest {
 
         // success
         executionInfo = ExecutionInfoBuilder.create().batch(true).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("Batch:True");
 
         // fail
         executionInfo = ExecutionInfoBuilder.create().batch(false).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("Batch:False");
     }
 
@@ -468,11 +481,11 @@ public class DefaultQueryLogEntryCreatorTest {
 
         // default
         executionInfo = ExecutionInfoBuilder.create().build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("BatchSize:0");
 
         executionInfo = ExecutionInfoBuilder.create().batchSize(100).build();
-        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
         assertThat(result).containsOnlyOnce("BatchSize:100");
     }
 
@@ -483,12 +496,12 @@ public class DefaultQueryLogEntryCreatorTest {
         creator.setMultiline(true);
 
         ExecutionInfo executionInfo = ExecutionInfoBuilder.create().build();
-        String result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true);
+        String result = creator.getLogEntry(executionInfo, new ArrayList<QueryInfo>(), true, true, true);
 
         assertThat(result).hasLineCount(5);
         String[] lines = result.split(LINE_SEPARATOR);
         assertThat(lines[0]).isEqualTo("");
-        assertThat(lines[1]).contains("Name", "Time", "Success");
+        assertThat(lines[1]).contains("Name", "Connection", "Isolation", "Time", "Success");
         assertThat(lines[2]).contains("Type", "Batch", "QuerySize", "BatchSize");
         assertThat(lines[3]).contains("Query");
         assertThat(lines[4]).contains("Params");

--- a/src/test/java/net/ttddyy/dsproxy/listener/logging/OutputParameterJsonLogEntryCreatorTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/listener/logging/OutputParameterJsonLogEntryCreatorTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.sql.CallableStatement;
+import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -71,6 +72,7 @@ public class OutputParameterJsonLogEntryCreatorTest {
                 .create()
                 .dataSourceName("foo")
                 .elapsedTime(100)
+                .isolationLevel(Connection.TRANSACTION_READ_COMMITTED)
                 .method(method)
                 .result(result)
                 .statementType(StatementType.CALLABLE)
@@ -83,7 +85,7 @@ public class OutputParameterJsonLogEntryCreatorTest {
 
         OutputParameterJsonLogEntryCreator creator = new OutputParameterJsonLogEntryCreator();
 
-        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true);
+        String jsonEntry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true, true);
         assertThat(jsonEntry).containsOnlyOnce("\"outParams\":[{\"1\":\"100\",\"foo\":\"101\"},{\"2\":\"200\",\"bar\":\"201\"}]");
 
 

--- a/src/test/java/net/ttddyy/dsproxy/listener/logging/OutputParameterLogEntryCreatorTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/listener/logging/OutputParameterLogEntryCreatorTest.java
@@ -83,7 +83,7 @@ public class OutputParameterLogEntryCreatorTest {
 
         OutputParameterLogEntryCreator creator = new OutputParameterLogEntryCreator();
 
-        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true);
+        String entry = creator.getLogEntry(executionInfo, Lists.newArrayList(queryInfo), false, true, false);
         assertThat(entry).containsOnlyOnce("OutParams:[(1=100,foo=101),(2=200,bar=201)]");
 
     }

--- a/src/test/java/net/ttddyy/dsproxy/proxy/DataSourceProxyLogicMockTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/proxy/DataSourceProxyLogicMockTest.java
@@ -40,8 +40,9 @@ public class DataSourceProxyLogicMockTest {
         verify(ds).getConnection();
     }
 
-    private DataSourceProxyLogic getProxyLogic(DataSource ds) {
+    private DataSourceProxyLogic getProxyLogic(DataSource ds) throws Throwable {
         QueryExecutionListener listener = mock(QueryExecutionListener.class);
+        when(ds.getConnection()).thenReturn(mock(Connection.class));
 
         ProxyConfig proxyConfig = ProxyConfig.Builder.create()
                 .dataSourceName(DS_NAME)
@@ -146,6 +147,7 @@ public class DataSourceProxyLogicMockTest {
         CallCheckMethodExecutionListener listener = new CallCheckMethodExecutionListener();
 
         DataSource ds = mock(DataSource.class);
+        when(ds.getConnection()).thenReturn(mock(Connection.class));
 
         ProxyConfig proxyConfig = ProxyConfig.Builder.create()
                 .dataSourceName(DS_NAME)


### PR DESCRIPTION
Hi! Since queries can be executed using different transaction isolations levels, I've found that it's going to be useful to see Isolation level in logs:

```
Name:northwind, Connection:2, Isolation:SERIALIZABLE, Time:3, Success:True
Type:Statement, Batch:False, QuerySize:1, BatchSize:0
Query:["SELECT * FROM products LIMIT 1"]
```

```
Name:northwind, Connection:3, Isolation:REPEATABLE_READ, Time:37, Success:True
Type:Statement, Batch:False, QuerySize:1, BatchSize:0
Query:["SELECT * FROM customers LIMIT 1"]
```

I've created a commit that adds isolation level to logging message. However, if you find, that `Isolation` information is too verbose for being included by default in the log message, I can improve ProxyDataSourceBuilder  like this:
```java
   ProxyDataSourceBuilder.create(datasource)
              .logQueryBySlf4j(SLF4JLogLevel.INFO, "proxy ds - stats")
              .logIsolationLevel(true)
              .build();
```

Please leave your feedback, if you find this useful or if it needs to be improved.
Many thanks, Alexei Brinza.