### PR TITLE
Add filter support for query logging listeners

### DIFF
--- a/src/main/asciidoc/built-in-listeners.adoc
+++ b/src/main/asciidoc/built-in-listeners.adoc
@@ -87,6 +87,20 @@ return ProxyDataSourceBuilder
             .build()
 ----
 
+You can also filter which queries are logged by providing a `LoggingFilter`:
+
+[source,java]
+----
+builder
+  .logQueryBySlf4j()
+  // Only log queries that are not to the 'audit' table
+  .loggingFilter((execInfo, queryInfoList) ->
+    queryInfoList.stream().noneMatch(q -> q.getQuery().contains("audit"))
+  )
+----
+
+If no filter is set, all queries are logged (default behavior).
+
 === Slow Query Logging Listener
 
 When query takes more than specified threshold, `SlowQueryListener` executes a callback method.

--- a/src/main/asciidoc/changelog-1.11.x.adoc
+++ b/src/main/asciidoc/changelog-1.11.x.adoc
@@ -1,0 +1,11 @@
+[[changelog-1.11]]
+=== 1.11
+
+====  New Features
+
+* Filtering support for query logging
+(https://github.com/jdbc-observations/datasource-proxy/issues/127[Issue-127]).
+
+====  Improvements
+
+====  Bug Fixes

--- a/src/main/asciidoc/how-to-use.adoc
+++ b/src/main/asciidoc/how-to-use.adoc
@@ -17,6 +17,7 @@ Also, it provides builder methods to register built-in or custom listeners.
 DataSource dataSource =
     ProxyDataSourceBuilder.create(actualDataSource)  // pass original datasource
         .logQueryByCommons(INFO)    // logQueryBySlf4j(), logQueryByJUL(), logQueryToSysOut()
+        .loggingFilter(myFilter)    // filter which queries to log
         .countQuery()               // enable query count metrics
         .logSlowQueryByCommons(10, TimeUnit.MINUTES)  // also by sl4j, jul, system out
         .proxyResultSet()           // enable proxying ResultSet

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLoggingListener.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/AbstractQueryLoggingListener.java
@@ -17,6 +17,7 @@ public abstract class AbstractQueryLoggingListener implements QueryExecutionList
     protected boolean writeConnectionId = true;
     protected boolean writeIsolation;
     protected LoggingCondition loggingCondition;
+    protected LoggingFilter loggingFilter = LoggingFilter.ALLOW_ALL;
 
     @Override
     public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
@@ -24,8 +25,7 @@ public abstract class AbstractQueryLoggingListener implements QueryExecutionList
 
     @Override
     public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
-        // only perform logging logic when the condition returns true
-        if (this.loggingCondition.getAsBoolean()) {
+        if (this.loggingCondition.getAsBoolean() && this.loggingFilter.shouldLog(execInfo, queryInfoList)) {
             final String entry = getEntry(execInfo, queryInfoList);
             writeLog(entry);
         }
@@ -98,5 +98,23 @@ public abstract class AbstractQueryLoggingListener implements QueryExecutionList
      */
     public void setLoggingCondition(LoggingCondition loggingCondition) {
         this.loggingCondition = loggingCondition;
+    }
+
+    /**
+     * Filter that controls which queries are logged.
+     *
+     * @param loggingFilter the filter to use (set <code>null</code> to log all)
+     * @since 1.11
+     */
+    public void setLoggingFilter(LoggingFilter loggingFilter) {
+        this.loggingFilter = (loggingFilter != null) ? loggingFilter : LoggingFilter.ALLOW_ALL;
+    }
+
+    /**
+     * @return current logging filter
+     * @since 1.11
+     */
+    public LoggingFilter getLoggingFilter() {
+        return this.loggingFilter;
     }
 }

--- a/src/main/java/net/ttddyy/dsproxy/listener/logging/LoggingFilter.java
+++ b/src/main/java/net/ttddyy/dsproxy/listener/logging/LoggingFilter.java
@@ -1,0 +1,34 @@
+package net.ttddyy.dsproxy.listener.logging;
+
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+
+import java.util.List;
+
+/**
+ * Functional interface to be called for filtering queries to be logged.
+ *
+ * @see AbstractQueryLoggingListener
+ * @since 1.11
+ */
+// TODO: add @FunctionalInterface once codebase is java8
+public interface LoggingFilter {
+
+    /**
+     * Determines if the query should be logged.
+     *
+     * @param execInfo execution context
+     * @param queryInfoList list of queries
+     * @return true to log, false to skip
+     */
+    boolean shouldLog(ExecutionInfo execInfo, List<QueryInfo> queryInfoList);
+
+    /**
+     * Default filter that allows all queries to be logged.
+     */
+    LoggingFilter ALLOW_ALL = new LoggingFilter() {
+        public boolean shouldLog(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+            return true;
+        }
+    };
+}

--- a/src/main/java/net/ttddyy/dsproxy/support/ProxyDataSourceBuilder.java
+++ b/src/main/java/net/ttddyy/dsproxy/support/ProxyDataSourceBuilder.java
@@ -23,6 +23,7 @@ import net.ttddyy.dsproxy.listener.logging.JULSlowQueryListener;
 import net.ttddyy.dsproxy.listener.logging.Log4jLogLevel;
 import net.ttddyy.dsproxy.listener.logging.Log4jQueryLoggingListener;
 import net.ttddyy.dsproxy.listener.logging.Log4jSlowQueryListener;
+import net.ttddyy.dsproxy.listener.logging.LoggingFilter;
 import net.ttddyy.dsproxy.listener.logging.QueryLogEntryCreator;
 import net.ttddyy.dsproxy.listener.logging.SLF4JLogLevel;
 import net.ttddyy.dsproxy.listener.logging.SLF4JQueryLoggingListener;
@@ -95,6 +96,7 @@ public class ProxyDataSourceBuilder {
     private TracingMethodListener.TracingMessageConsumer tracingMessageConsumer;
 
     // For building QueryLoggingListeners
+    private LoggingFilter loggingFilter;
 
     // CommonsQueryLoggingListener
     private boolean createCommonsQueryListener;
@@ -781,6 +783,18 @@ public class ProxyDataSourceBuilder {
     }
 
     /**
+     * Register a {@link LoggingFilter}.
+     *
+     * @param loggingFilter a logging filter to register
+     * @return builder
+     * @since 1.11
+     */
+    public ProxyDataSourceBuilder loggingFilter(LoggingFilter loggingFilter) {
+        this.loggingFilter = loggingFilter;
+        return this;
+    }
+
+    /**
      * Take a callback that could format a query for logging.
      * <p>
      * This method is mutually exclusive to {@link #asJson()}.
@@ -1275,6 +1289,9 @@ public class ProxyDataSourceBuilder {
         if (this.retrieveIsolation && this.writeIsolation) {
             listener.setWriteIsolation(true);
         }
+        if (this.loggingFilter != null) {
+            listener.setLoggingFilter(this.loggingFilter);
+        }
         return listener;
     }
 
@@ -1304,6 +1321,9 @@ public class ProxyDataSourceBuilder {
         listener.setQueryLogEntryCreator(buildQueryLogEntryCreator());
         if (this.retrieveIsolation && this.writeIsolation) {
             listener.setWriteIsolation(true);
+        }
+        if (this.loggingFilter != null) {
+            listener.setLoggingFilter(this.loggingFilter);
         }
         return listener;
     }
@@ -1335,6 +1355,9 @@ public class ProxyDataSourceBuilder {
         if (this.retrieveIsolation && this.writeIsolation) {
             listener.setWriteIsolation(true);
         }
+        if (this.loggingFilter != null) {
+            listener.setLoggingFilter(this.loggingFilter);
+        }
         return listener;
     }
 
@@ -1365,6 +1388,9 @@ public class ProxyDataSourceBuilder {
         if (this.retrieveIsolation && this.writeIsolation) {
             listener.setWriteIsolation(true);
         }
+        if (this.loggingFilter != null) {
+            listener.setLoggingFilter(this.loggingFilter);
+        }
         return listener;
     }
 
@@ -1388,6 +1414,9 @@ public class ProxyDataSourceBuilder {
         listener.setQueryLogEntryCreator(buildQueryLogEntryCreator());
         if (this.retrieveIsolation && this.writeIsolation) {
             listener.setWriteIsolation(true);
+        }
+        if (this.loggingFilter != null) {
+            listener.setLoggingFilter(this.loggingFilter);
         }
         return listener;
     }


### PR DESCRIPTION
Introduce a LoggingFilter interface for all query logging listeners, configurable via ProxyDataSourceBuilder, with a default filter that allows all queries.

Resolves #127

### Implementation Remarks

Looking forward to your feedback.

- I assumed that this functionality would be part of the next minor release `1.11` and referenced that version. Feel free to adapt as neccessary.
- I decided to only use the configured logging filter for the normal query loggers and not the slow query loggers, as I consider these to be separate use cases.
- I tried to match the code and testing style. Nevertheless, do not hesitate to request changes or perform yourself.
- It should build with Java 6. The only >= Java 8 code is part of the documentation to keep it concise. That matches other example code which uses concepts such as method references.